### PR TITLE
build(deps-dev): update to typescript 2.8.0 for fixing bug with build

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@uirouter/cypress-runner": "^1.0.9",
     "shx": "^0.3.2",
     "source-map-loader": "^0.2.4",
-    "typescript": ">=2.7.2 <2.8.0",
+    "typescript": "^2.8.0",
     "webpack": "^4.22.0",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.14"


### PR DESCRIPTION
update to typescript 2.8.0 for fixing bug with build

ERROR in node_modules/@types/sinon/index.d.ts(1448,36): error TS1005: ';' expected.
node_modules/preact/dist/preact.d.ts(129,8): error TS1005: ';' expected.
node_modules/preact/dist/preact.d.ts(131,4): error TS1109: Expression expected.
node_modules/preact/dist/preact.d.ts(133,4): error TS1005: '(' expected.
node_modules/preact/dist/preact.d.ts(134,3): error TS1005: '(' expected.
node_modules/preact/dist/preact.d.ts(134,10): error TS1005: ')' expected.
node_modules/preact/dist/preact.d.ts(153,14): error TS1005: ';' expected.
node_modules/preact/dist/preact.d.ts(153,44): error TS1005: ';' expected.
node_modules/preact/dist/preact.d.ts(154,5): error TS1128: Declaration or statement expected.
node_modules/preact/dist/preact.d.ts(155,5): error TS1005: '(' expected.
node_modules/preact/dist/preact.d.ts(155,12): error TS1005: ')' expected.
